### PR TITLE
Revert "Revert openssl fips mode setting"

### DIFF
--- a/src/openssl.patch/10-support-fips-mode.patch
+++ b/src/openssl.patch/10-support-fips-mode.patch
@@ -161,6 +161,23 @@ index 1b0d523bea..31fbd42cd2 100644
  # ifndef OPENSSL_NO_STATIC_ENGINE
  #  if !defined(OPENSSL_NO_HW) && !defined(OPENSSL_NO_HW_PADLOCK)
      if ((opts & OPENSSL_INIT_ENGINE_PADLOCK)
+diff --git a/crypto/o_fips.c b/crypto/o_fips.c
+index 050ea9c216..6e9ffdb1d9 100644
+--- a/crypto/o_fips.c
++++ b/crypto/o_fips.c
+@@ -9,8 +9,12 @@
+ 
+ #include "internal/cryptlib.h"
+ 
++extern int g_fips_mode_enabled;
+ int FIPS_mode(void)
+ {
++    if (g_fips_mode_enabled == 1){
++        return g_fips_mode_enabled;
++    }
+     /* This version of the library does not support FIPS mode. */
+     return 0;
+ }
 diff --git a/crypto/engine/build.info b/crypto/engine/build.info
 index e00802a3fd..66bb39fa38 100644
 --- a/crypto/engine/build.info


### PR DESCRIPTION
This reverts commit 5882a3e05a7c55b76dab3beb98b4ee0342f7c17f.

Set the FIPS_mode() return value to 1 if FIPS enabled.
It will have impacted on the performance when FIPS enabled, the SONIC test sonictest-t1-lag will increase around 30 minutes.