### PR TITLE
[Ci] Support to publish all debian packages

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -85,7 +85,9 @@ jobs:
     displayName: 'Test openssl with fips enabled'
  
   - script: |
+      set -ex
       ARCH=${{ parameters.arch }} make all
+      cp src/*.deb target/
     displayName: 'Build others'
   - publish: $(System.DefaultWorkingDirectory)/target
     artifact: fips-symcrypt-${{ parameters.arch }}


### PR DESCRIPTION
It is to fix some of the krb5 packages not published issue.
Support to collect all debian packages, some of the pacakges are for dev, it may be useful in some of the scenarios.
