### PR TITLE
Fix go build break because cert expired issue.

### DIFF
--- a/src/golang/patches/go_testcase_cert_expire.patch
+++ b/src/golang/patches/go_testcase_cert_expire.patch
@@ -1,0 +1,248 @@
+From 223260bc63bfc1a3120face5bbc49285f6c32357 Mon Sep 17 00:00:00 2001
+From: Filippo Valsorda <filippo@golang.org>
+Date: Thu, 02 Jan 2025 01:34:40 +0100
+Subject: [PATCH] [release-branch.go1.22] crypto/tls: fix Config.Time in tests using expired certificates
+
+Updates #71077
+Fixes #71103
+
+Change-Id: I6a6a465685f3bd50a5bb35a160f87b59b74fa6af
+Reviewed-on: https://go-review.googlesource.com/c/go/+/639655
+Auto-Submit: Ian Lance Taylor <iant@google.com>
+Reviewed-by: Damien Neil <dneil@google.com>
+LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
+Auto-Submit: Filippo Valsorda <filippo@golang.org>
+Auto-Submit: Damien Neil <dneil@google.com>
+Reviewed-by: Joel Sing <joel@sing.id.au>
+Reviewed-by: Ian Lance Taylor <iant@google.com>
+Reviewed-on: https://go-review.googlesource.com/c/go/+/640237
+---
+
+diff --git a/src/crypto/tls/handshake_client_test.go b/src/crypto/tls/handshake_client_test.go
+index ee9e79a..39f3e90 100644
+--- a/src/crypto/tls/handshake_client_test.go
++++ b/src/crypto/tls/handshake_client_test.go
+@@ -881,6 +881,7 @@
+ 		MaxVersion:   version,
+ 		CipherSuites: []uint16{TLS_RSA_WITH_RC4_128_SHA, TLS_ECDHE_RSA_WITH_RC4_128_SHA},
+ 		Certificates: testConfig.Certificates,
++		Time:         testTime,
+ 	}
+ 
+ 	issuer, err := x509.ParseCertificate(testRSACertificateIssuer)
+@@ -897,6 +898,7 @@
+ 		ClientSessionCache: NewLRUClientSessionCache(32),
+ 		RootCAs:            rootCAs,
+ 		ServerName:         "example.golang",
++		Time:               testTime,
+ 	}
+ 
+ 	testResumeState := func(test string, didResume bool) {
+@@ -943,7 +945,7 @@
+ 
+ 	// An old session ticket is replaced with a ticket encrypted with a fresh key.
+ 	ticket = getTicket()
+-	serverConfig.Time = func() time.Time { return time.Now().Add(24*time.Hour + time.Minute) }
++	serverConfig.Time = func() time.Time { return testTime().Add(24*time.Hour + time.Minute) }
+ 	testResumeState("ResumeWithOldTicket", true)
+ 	if bytes.Equal(ticket, getTicket()) {
+ 		t.Fatal("old first ticket matches the fresh one")
+@@ -951,13 +953,13 @@
+ 
+ 	// Once the session master secret is expired, a full handshake should occur.
+ 	ticket = getTicket()
+-	serverConfig.Time = func() time.Time { return time.Now().Add(24*8*time.Hour + time.Minute) }
++	serverConfig.Time = func() time.Time { return testTime().Add(24*8*time.Hour + time.Minute) }
+ 	testResumeState("ResumeWithExpiredTicket", false)
+ 	if bytes.Equal(ticket, getTicket()) {
+ 		t.Fatal("expired first ticket matches the fresh one")
+ 	}
+ 
+-	serverConfig.Time = func() time.Time { return time.Now() } // reset the time back
++	serverConfig.Time = testTime // reset the time back
+ 	key1 := randomKey()
+ 	serverConfig.SetSessionTicketKeys([][32]byte{key1})
+ 
+@@ -974,11 +976,11 @@
+ 	testResumeState("KeyChangeFinish", true)
+ 
+ 	// Age the session ticket a bit, but not yet expired.
+-	serverConfig.Time = func() time.Time { return time.Now().Add(24*time.Hour + time.Minute) }
++	serverConfig.Time = func() time.Time { return testTime().Add(24*time.Hour + time.Minute) }
+ 	testResumeState("OldSessionTicket", true)
+ 	ticket = getTicket()
+ 	// Expire the session ticket, which would force a full handshake.
+-	serverConfig.Time = func() time.Time { return time.Now().Add(24*8*time.Hour + time.Minute) }
++	serverConfig.Time = func() time.Time { return testTime().Add(24*8*time.Hour + 2*time.Minute) }
+ 	testResumeState("ExpiredSessionTicket", false)
+ 	if bytes.Equal(ticket, getTicket()) {
+ 		t.Fatal("new ticket wasn't provided after old ticket expired")
+@@ -986,7 +988,7 @@
+ 
+ 	// Age the session ticket a bit at a time, but don't expire it.
+ 	d := 0 * time.Hour
+-	serverConfig.Time = func() time.Time { return time.Now().Add(d) }
++	serverConfig.Time = func() time.Time { return testTime().Add(d) }
+ 	deleteTicket()
+ 	testResumeState("GetFreshSessionTicket", false)
+ 	for i := 0; i < 13; i++ {
+@@ -997,7 +999,7 @@
+ 	// handshake occurs for TLS 1.2. Resumption should still occur for
+ 	// TLS 1.3 since the client should be using a fresh ticket sent over
+ 	// by the server.
+-	d += 12 * time.Hour
++	d += 12*time.Hour + time.Minute
+ 	if version == VersionTLS13 {
+ 		testResumeState("ExpiredSessionTicket", true)
+ 	} else {
+@@ -1013,6 +1015,7 @@
+ 		MaxVersion:   version,
+ 		CipherSuites: []uint16{TLS_RSA_WITH_RC4_128_SHA, TLS_ECDHE_RSA_WITH_RC4_128_SHA},
+ 		Certificates: testConfig.Certificates,
++		Time:         testTime,
+ 	}
+ 	serverConfig.SetSessionTicketKeys([][32]byte{key2})
+ 
+@@ -1038,6 +1041,7 @@
+ 			CurvePreferences: []CurveID{CurveP521, CurveP384, CurveP256},
+ 			MaxVersion:       version,
+ 			Certificates:     testConfig.Certificates,
++			Time:             testTime,
+ 		}
+ 		testResumeState("InitialHandshake", false)
+ 		testResumeState("WithHelloRetryRequest", true)
+@@ -1047,6 +1051,7 @@
+ 			MaxVersion:   version,
+ 			CipherSuites: []uint16{TLS_RSA_WITH_RC4_128_SHA, TLS_ECDHE_RSA_WITH_RC4_128_SHA},
+ 			Certificates: testConfig.Certificates,
++			Time:         testTime,
+ 		}
+ 	}
+ 
+@@ -1761,6 +1766,7 @@
+ 		serverConfig := &Config{
+ 			MaxVersion:   version,
+ 			Certificates: []Certificate{testConfig.Certificates[0]},
++			Time:         testTime,
+ 			ClientCAs:    rootCAs,
+ 			NextProtos:   []string{"protocol1"},
+ 		}
+@@ -1774,6 +1780,7 @@
+ 			RootCAs:            rootCAs,
+ 			ServerName:         "example.golang",
+ 			Certificates:       []Certificate{testConfig.Certificates[0]},
++			Time:               testTime,
+ 			NextProtos:         []string{"protocol1"},
+ 		}
+ 		test.configureClient(clientConfig, &clientCalled)
+@@ -1816,8 +1823,6 @@
+ 	rootCAs := x509.NewCertPool()
+ 	rootCAs.AddCert(issuer)
+ 
+-	now := func() time.Time { return time.Unix(1476984729, 0) }
+-
+ 	sentinelErr := errors.New("TestVerifyPeerCertificate")
+ 
+ 	verifyPeerCertificateCallback := func(called *bool, rawCerts [][]byte, validatedChains [][]*x509.Certificate) error {
+@@ -2063,7 +2068,7 @@
+ 			config.ServerName = "example.golang"
+ 			config.ClientAuth = RequireAndVerifyClientCert
+ 			config.ClientCAs = rootCAs
+-			config.Time = now
++			config.Time = testTime
+ 			config.MaxVersion = version
+ 			config.Certificates = make([]Certificate, 1)
+ 			config.Certificates[0].Certificate = [][]byte{testRSACertificate}
+@@ -2080,7 +2085,7 @@
+ 		config := testConfig.Clone()
+ 		config.ServerName = "example.golang"
+ 		config.RootCAs = rootCAs
+-		config.Time = now
++		config.Time = testTime
+ 		config.MaxVersion = version
+ 		test.configureClient(config, &clientCalled)
+ 		clientErr := Client(c, config).Handshake()
+@@ -2393,7 +2398,7 @@
+ 		serverConfig.RootCAs = x509.NewCertPool()
+ 		serverConfig.RootCAs.AddCert(issuer)
+ 		serverConfig.ClientCAs = serverConfig.RootCAs
+-		serverConfig.Time = func() time.Time { return time.Unix(1476984729, 0) }
++		serverConfig.Time = testTime
+ 		serverConfig.MaxVersion = version
+ 
+ 		clientConfig := testConfig.Clone()
+@@ -2564,6 +2569,7 @@
+ 		ClientSessionCache: NewLRUClientSessionCache(32),
+ 		ServerName:         "example.golang",
+ 		RootCAs:            roots,
++		Time:               testTime,
+ 	}
+ 	serverConfig := testConfig.Clone()
+ 	serverConfig.MaxVersion = ver
+diff --git a/src/crypto/tls/handshake_server_test.go b/src/crypto/tls/handshake_server_test.go
+index 15db760..0f10a3e 100644
+--- a/src/crypto/tls/handshake_server_test.go
++++ b/src/crypto/tls/handshake_server_test.go
+@@ -482,6 +482,7 @@
+ 	serverConfig := &Config{
+ 		CipherSuites: []uint16{TLS_RSA_WITH_AES_128_CBC_SHA},
+ 		Certificates: testConfig.Certificates,
++		Time:         testTime,
+ 	}
+ 	clientConfig := &Config{
+ 		CipherSuites:       []uint16{TLS_RSA_WITH_AES_128_CBC_SHA},
+@@ -489,6 +490,7 @@
+ 		ClientSessionCache: NewLRUClientSessionCache(1),
+ 		ServerName:         "servername",
+ 		MinVersion:         VersionTLS12,
++		Time:               testTime,
+ 	}
+ 
+ 	// Establish a session at TLS 1.3.
+diff --git a/src/crypto/tls/handshake_test.go b/src/crypto/tls/handshake_test.go
+index bacc8b7..27ab19e 100644
+--- a/src/crypto/tls/handshake_test.go
++++ b/src/crypto/tls/handshake_test.go
+@@ -429,6 +429,11 @@
+ 	return b
+ }
+ 
++// testTime is 2016-10-20T17:32:09.000Z, which is within the validity period of
++// [testRSACertificate], [testRSACertificateIssuer], [testRSA2048Certificate],
++// [testRSA2048CertificateIssuer], and [testECDSACertificate].
++var testTime = func() time.Time { return time.Unix(1476984729, 0) }
++
+ var testRSACertificate = fromHex("3082024b308201b4a003020102020900e8f09d3fe25beaa6300d06092a864886f70d01010b0500301f310b3009060355040a1302476f3110300e06035504031307476f20526f6f74301e170d3136303130313030303030305a170d3235303130313030303030305a301a310b3009060355040a1302476f310b300906035504031302476f30819f300d06092a864886f70d010101050003818d0030818902818100db467d932e12270648bc062821ab7ec4b6a25dfe1e5245887a3647a5080d92425bc281c0be97799840fb4f6d14fd2b138bc2a52e67d8d4099ed62238b74a0b74732bc234f1d193e596d9747bf3589f6c613cc0b041d4d92b2b2423775b1c3bbd755dce2054cfa163871d1e24c4f31d1a508baab61443ed97a77562f414c852d70203010001a38193308190300e0603551d0f0101ff0404030205a0301d0603551d250416301406082b0601050507030106082b06010505070302300c0603551d130101ff0402300030190603551d0e041204109f91161f43433e49a6de6db680d79f60301b0603551d230414301280104813494d137e1631bba301d5acab6e7b30190603551d1104123010820e6578616d706c652e676f6c616e67300d06092a864886f70d01010b0500038181009d30cc402b5b50a061cbbae55358e1ed8328a9581aa938a495a1ac315a1a84663d43d32dd90bf297dfd320643892243a00bccf9c7db74020015faad3166109a276fd13c3cce10c5ceeb18782f16c04ed73bbb343778d0c1cf10fa1d8408361c94c722b9daedb4606064df4c1b33ec0d1bd42d4dbfe3d1360845c21d33be9fae7")
+ 
+ var testRSACertificateIssuer = fromHex("3082021930820182a003020102020900ca5e4e811a965964300d06092a864886f70d01010b0500301f310b3009060355040a1302476f3110300e06035504031307476f20526f6f74301e170d3136303130313030303030305a170d3235303130313030303030305a301f310b3009060355040a1302476f3110300e06035504031307476f20526f6f7430819f300d06092a864886f70d010101050003818d0030818902818100d667b378bb22f34143b6cd2008236abefaf2852adf3ab05e01329e2c14834f5105df3f3073f99dab5442d45ee5f8f57b0111c8cb682fbb719a86944eebfffef3406206d898b8c1b1887797c9c5006547bb8f00e694b7a063f10839f269f2c34fff7a1f4b21fbcd6bfdfb13ac792d1d11f277b5c5b48600992203059f2a8f8cc50203010001a35d305b300e0603551d0f0101ff040403020204301d0603551d250416301406082b0601050507030106082b06010505070302300f0603551d130101ff040530030101ff30190603551d0e041204104813494d137e1631bba301d5acab6e7b300d06092a864886f70d01010b050003818100c1154b4bab5266221f293766ae4138899bd4c5e36b13cee670ceeaa4cbdf4f6679017e2fe649765af545749fe4249418a56bd38a04b81e261f5ce86b8d5c65413156a50d12449554748c59a30c515bc36a59d38bddf51173e899820b282e40aa78c806526fd184fb6b4cf186ec728edffa585440d2b3225325f7ab580e87dd76")
+diff --git a/src/crypto/tls/tls_test.go b/src/crypto/tls/tls_test.go
+index 42a0272..99bd700 100644
+--- a/src/crypto/tls/tls_test.go
++++ b/src/crypto/tls/tls_test.go
+@@ -1098,8 +1098,6 @@
+ 	rootCAs := x509.NewCertPool()
+ 	rootCAs.AddCert(issuer)
+ 
+-	now := func() time.Time { return time.Unix(1476984729, 0) }
+-
+ 	const alpnProtocol = "golang"
+ 	const serverName = "example.golang"
+ 	var scts = [][]byte{[]byte("dummy sct 1"), []byte("dummy sct 2")}
+@@ -1115,7 +1113,7 @@
+ 		}
+ 		t.Run(name, func(t *testing.T) {
+ 			config := &Config{
+-				Time:         now,
++				Time:         testTime,
+ 				Rand:         zeroSource{},
+ 				Certificates: make([]Certificate, 1),
+ 				MaxVersion:   v,
+@@ -1729,7 +1727,7 @@
+ 			var serverVerifyPeerCertificates, clientVerifyPeerCertificates bool
+ 
+ 			clientConfig := testConfig.Clone()
+-			clientConfig.Time = func() time.Time { return time.Unix(1476984729, 0) }
++			clientConfig.Time = testTime
+ 			clientConfig.MaxVersion = version
+ 			clientConfig.MinVersion = version
+ 			clientConfig.RootCAs = rootCAs

--- a/src/golang/patches/go_testcase_cert_expire.patch
+++ b/src/golang/patches/go_testcase_cert_expire.patch
@@ -17,125 +17,112 @@ Reviewed-by: Joel Sing <joel@sing.id.au>
 Reviewed-by: Ian Lance Taylor <iant@google.com>
 Reviewed-on: https://go-review.googlesource.com/c/go/+/640237
 ---
+ src/crypto/tls/handshake_client_test.go | 28 ++++++++++++++-----------
+ src/crypto/tls/handshake_server_test.go |  2 ++
+ src/crypto/tls/handshake_test.go        |  5 +++++
+ src/crypto/tls/tls_test.go              |  4 +---
+ 4 files changed, 24 insertions(+), 15 deletions(-)
 
 diff --git a/src/crypto/tls/handshake_client_test.go b/src/crypto/tls/handshake_client_test.go
-index ee9e79a..39f3e90 100644
+index 2e37a18..ae1c795 100644
 --- a/src/crypto/tls/handshake_client_test.go
 +++ b/src/crypto/tls/handshake_client_test.go
-@@ -881,6 +881,7 @@
+@@ -881,6 +881,7 @@ func testResumption(t *testing.T, version uint16) {
  		MaxVersion:   version,
  		CipherSuites: []uint16{TLS_RSA_WITH_RC4_128_SHA, TLS_ECDHE_RSA_WITH_RC4_128_SHA},
  		Certificates: testConfig.Certificates,
-+		Time:         testTime,
++ 		Time:         testTime,
  	}
  
  	issuer, err := x509.ParseCertificate(testRSACertificateIssuer)
-@@ -897,6 +898,7 @@
+@@ -897,6 +898,7 @@ func testResumption(t *testing.T, version uint16) {
  		ClientSessionCache: NewLRUClientSessionCache(32),
  		RootCAs:            rootCAs,
  		ServerName:         "example.golang",
-+		Time:               testTime,
++ 		Time:               testTime,
  	}
  
  	testResumeState := func(test string, didResume bool) {
-@@ -943,7 +945,7 @@
+@@ -944,20 +946,20 @@ func testResumption(t *testing.T, version uint16) {
+ 	}
  
- 	// An old session ticket is replaced with a ticket encrypted with a fresh key.
- 	ticket = getTicket()
+ 	// An old session ticket can resume, but the server will provide a ticket encrypted with a fresh key.
 -	serverConfig.Time = func() time.Time { return time.Now().Add(24*time.Hour + time.Minute) }
-+	serverConfig.Time = func() time.Time { return testTime().Add(24*time.Hour + time.Minute) }
++ 	serverConfig.Time = func() time.Time { return testTime().Add(24*time.Hour + time.Minute) }
  	testResumeState("ResumeWithOldTicket", true)
- 	if bytes.Equal(ticket, getTicket()) {
+ 	if bytes.Equal(ticket[:ticketKeyNameLen], getTicket()[:ticketKeyNameLen]) {
  		t.Fatal("old first ticket matches the fresh one")
-@@ -951,13 +953,13 @@
+ 	}
  
- 	// Once the session master secret is expired, a full handshake should occur.
- 	ticket = getTicket()
+ 	// Now the session tickey key is expired, so a full handshake should occur.
 -	serverConfig.Time = func() time.Time { return time.Now().Add(24*8*time.Hour + time.Minute) }
-+	serverConfig.Time = func() time.Time { return testTime().Add(24*8*time.Hour + time.Minute) }
++ 	serverConfig.Time = func() time.Time { return testTime().Add(24*8*time.Hour + time.Minute) }
  	testResumeState("ResumeWithExpiredTicket", false)
  	if bytes.Equal(ticket, getTicket()) {
  		t.Fatal("expired first ticket matches the fresh one")
  	}
  
 -	serverConfig.Time = func() time.Time { return time.Now() } // reset the time back
-+	serverConfig.Time = testTime // reset the time back
++ 	serverConfig.Time = testTime // reset the time back
  	key1 := randomKey()
  	serverConfig.SetSessionTicketKeys([][32]byte{key1})
  
-@@ -974,11 +976,11 @@
+@@ -974,11 +976,11 @@ func testResumption(t *testing.T, version uint16) {
  	testResumeState("KeyChangeFinish", true)
  
  	// Age the session ticket a bit, but not yet expired.
 -	serverConfig.Time = func() time.Time { return time.Now().Add(24*time.Hour + time.Minute) }
-+	serverConfig.Time = func() time.Time { return testTime().Add(24*time.Hour + time.Minute) }
++ 	serverConfig.Time = func() time.Time { return testTime().Add(24*time.Hour + time.Minute) }
  	testResumeState("OldSessionTicket", true)
  	ticket = getTicket()
  	// Expire the session ticket, which would force a full handshake.
 -	serverConfig.Time = func() time.Time { return time.Now().Add(24*8*time.Hour + time.Minute) }
-+	serverConfig.Time = func() time.Time { return testTime().Add(24*8*time.Hour + 2*time.Minute) }
++ 	serverConfig.Time = func() time.Time { return testTime().Add(24*8*time.Hour + 2*time.Minute) }
  	testResumeState("ExpiredSessionTicket", false)
  	if bytes.Equal(ticket, getTicket()) {
  		t.Fatal("new ticket wasn't provided after old ticket expired")
-@@ -986,7 +988,7 @@
- 
- 	// Age the session ticket a bit at a time, but don't expire it.
+@@ -988,14 +990,14 @@ func testResumption(t *testing.T, version uint16) {
  	d := 0 * time.Hour
--	serverConfig.Time = func() time.Time { return time.Now().Add(d) }
-+	serverConfig.Time = func() time.Time { return testTime().Add(d) }
- 	deleteTicket()
- 	testResumeState("GetFreshSessionTicket", false)
  	for i := 0; i < 13; i++ {
-@@ -997,7 +999,7 @@
+ 		d += 12 * time.Hour
+-		serverConfig.Time = func() time.Time { return time.Now().Add(d) }
++ 	    serverConfig.Time = func() time.Time { return testTime().Add(d) }
+ 		testResumeState("OldSessionTicket", true)
+ 	}
+ 	// Expire it (now a little more than 7 days) and make sure a full
  	// handshake occurs for TLS 1.2. Resumption should still occur for
  	// TLS 1.3 since the client should be using a fresh ticket sent over
  	// by the server.
 -	d += 12 * time.Hour
-+	d += 12*time.Hour + time.Minute
++ 	d += 12*time.Hour + time.Minute
+ 	serverConfig.Time = func() time.Time { return time.Now().Add(d) }
  	if version == VersionTLS13 {
  		testResumeState("ExpiredSessionTicket", true)
- 	} else {
-@@ -1013,6 +1015,7 @@
+@@ -1012,6 +1014,7 @@ func testResumption(t *testing.T, version uint16) {
  		MaxVersion:   version,
  		CipherSuites: []uint16{TLS_RSA_WITH_RC4_128_SHA, TLS_ECDHE_RSA_WITH_RC4_128_SHA},
  		Certificates: testConfig.Certificates,
-+		Time:         testTime,
++ 		Time:         testTime,
  	}
  	serverConfig.SetSessionTicketKeys([][32]byte{key2})
  
-@@ -1038,6 +1041,7 @@
- 			CurvePreferences: []CurveID{CurveP521, CurveP384, CurveP256},
- 			MaxVersion:       version,
- 			Certificates:     testConfig.Certificates,
-+			Time:             testTime,
- 		}
- 		testResumeState("InitialHandshake", false)
- 		testResumeState("WithHelloRetryRequest", true)
-@@ -1047,6 +1051,7 @@
- 			MaxVersion:   version,
- 			CipherSuites: []uint16{TLS_RSA_WITH_RC4_128_SHA, TLS_ECDHE_RSA_WITH_RC4_128_SHA},
- 			Certificates: testConfig.Certificates,
-+			Time:         testTime,
- 		}
- 	}
- 
-@@ -1761,6 +1766,7 @@
+@@ -1698,6 +1701,7 @@ func testVerifyConnection(t *testing.T, version uint16) {
  		serverConfig := &Config{
  			MaxVersion:   version,
  			Certificates: []Certificate{testConfig.Certificates[0]},
-+			Time:         testTime,
++ 			Time:         testTime,
  			ClientCAs:    rootCAs,
  			NextProtos:   []string{"protocol1"},
  		}
-@@ -1774,6 +1780,7 @@
+@@ -1711,6 +1715,7 @@ func testVerifyConnection(t *testing.T, version uint16) {
  			RootCAs:            rootCAs,
  			ServerName:         "example.golang",
  			Certificates:       []Certificate{testConfig.Certificates[0]},
-+			Time:               testTime,
++ 			Time:               testTime,
  			NextProtos:         []string{"protocol1"},
  		}
  		test.configureClient(clientConfig, &clientCalled)
-@@ -1816,8 +1823,6 @@
+@@ -1753,8 +1758,6 @@ func testVerifyPeerCertificate(t *testing.T, version uint16) {
  	rootCAs := x509.NewCertPool()
  	rootCAs.AddCert(issuer)
  
@@ -144,34 +131,34 @@ index ee9e79a..39f3e90 100644
  	sentinelErr := errors.New("TestVerifyPeerCertificate")
  
  	verifyPeerCertificateCallback := func(called *bool, rawCerts [][]byte, validatedChains [][]*x509.Certificate) error {
-@@ -2063,7 +2068,7 @@
+@@ -2000,7 +2003,7 @@ func testVerifyPeerCertificate(t *testing.T, version uint16) {
  			config.ServerName = "example.golang"
  			config.ClientAuth = RequireAndVerifyClientCert
  			config.ClientCAs = rootCAs
 -			config.Time = now
-+			config.Time = testTime
++ 			config.Time = testTime
  			config.MaxVersion = version
  			config.Certificates = make([]Certificate, 1)
  			config.Certificates[0].Certificate = [][]byte{testRSACertificate}
-@@ -2080,7 +2085,7 @@
+@@ -2017,7 +2020,7 @@ func testVerifyPeerCertificate(t *testing.T, version uint16) {
  		config := testConfig.Clone()
  		config.ServerName = "example.golang"
  		config.RootCAs = rootCAs
 -		config.Time = now
-+		config.Time = testTime
++ 		config.Time = testTime
  		config.MaxVersion = version
  		test.configureClient(config, &clientCalled)
  		clientErr := Client(c, config).Handshake()
-@@ -2393,7 +2398,7 @@
+@@ -2331,7 +2334,7 @@ func testGetClientCertificate(t *testing.T, version uint16) {
  		serverConfig.RootCAs = x509.NewCertPool()
  		serverConfig.RootCAs.AddCert(issuer)
  		serverConfig.ClientCAs = serverConfig.RootCAs
 -		serverConfig.Time = func() time.Time { return time.Unix(1476984729, 0) }
-+		serverConfig.Time = testTime
++ 		serverConfig.Time = testTime
  		serverConfig.MaxVersion = version
  
  		clientConfig := testConfig.Clone()
-@@ -2564,6 +2569,7 @@
+@@ -2502,6 +2505,7 @@ func testResumptionKeepsOCSPAndSCT(t *testing.T, ver uint16) {
  		ClientSessionCache: NewLRUClientSessionCache(32),
  		ServerName:         "example.golang",
  		RootCAs:            roots,
@@ -180,10 +167,10 @@ index ee9e79a..39f3e90 100644
  	serverConfig := testConfig.Clone()
  	serverConfig.MaxVersion = ver
 diff --git a/src/crypto/tls/handshake_server_test.go b/src/crypto/tls/handshake_server_test.go
-index 15db760..0f10a3e 100644
+index b2e8107..8ac760a 100644
 --- a/src/crypto/tls/handshake_server_test.go
 +++ b/src/crypto/tls/handshake_server_test.go
-@@ -482,6 +482,7 @@
+@@ -481,6 +481,7 @@ func testCrossVersionResume(t *testing.T, version uint16) {
  	serverConfig := &Config{
  		CipherSuites: []uint16{TLS_RSA_WITH_AES_128_CBC_SHA},
  		Certificates: testConfig.Certificates,
@@ -191,19 +178,19 @@ index 15db760..0f10a3e 100644
  	}
  	clientConfig := &Config{
  		CipherSuites:       []uint16{TLS_RSA_WITH_AES_128_CBC_SHA},
-@@ -489,6 +490,7 @@
+@@ -488,6 +489,7 @@ func testCrossVersionResume(t *testing.T, version uint16) {
  		ClientSessionCache: NewLRUClientSessionCache(1),
  		ServerName:         "servername",
- 		MinVersion:         VersionTLS12,
+ 		MinVersion:         VersionTLS10,
 +		Time:               testTime,
  	}
  
- 	// Establish a session at TLS 1.3.
+ 	// Establish a session at TLS 1.1.
 diff --git a/src/crypto/tls/handshake_test.go b/src/crypto/tls/handshake_test.go
 index bacc8b7..27ab19e 100644
 --- a/src/crypto/tls/handshake_test.go
 +++ b/src/crypto/tls/handshake_test.go
-@@ -429,6 +429,11 @@
+@@ -429,6 +429,11 @@ func fromHex(s string) []byte {
  	return b
  }
  
@@ -216,10 +203,10 @@ index bacc8b7..27ab19e 100644
  
  var testRSACertificateIssuer = fromHex("3082021930820182a003020102020900ca5e4e811a965964300d06092a864886f70d01010b0500301f310b3009060355040a1302476f3110300e06035504031307476f20526f6f74301e170d3136303130313030303030305a170d3235303130313030303030305a301f310b3009060355040a1302476f3110300e06035504031307476f20526f6f7430819f300d06092a864886f70d010101050003818d0030818902818100d667b378bb22f34143b6cd2008236abefaf2852adf3ab05e01329e2c14834f5105df3f3073f99dab5442d45ee5f8f57b0111c8cb682fbb719a86944eebfffef3406206d898b8c1b1887797c9c5006547bb8f00e694b7a063f10839f269f2c34fff7a1f4b21fbcd6bfdfb13ac792d1d11f277b5c5b48600992203059f2a8f8cc50203010001a35d305b300e0603551d0f0101ff040403020204301d0603551d250416301406082b0601050507030106082b06010505070302300f0603551d130101ff040530030101ff30190603551d0e041204104813494d137e1631bba301d5acab6e7b300d06092a864886f70d01010b050003818100c1154b4bab5266221f293766ae4138899bd4c5e36b13cee670ceeaa4cbdf4f6679017e2fe649765af545749fe4249418a56bd38a04b81e261f5ce86b8d5c65413156a50d12449554748c59a30c515bc36a59d38bddf51173e899820b282e40aa78c806526fd184fb6b4cf186ec728edffa585440d2b3225325f7ab580e87dd76")
 diff --git a/src/crypto/tls/tls_test.go b/src/crypto/tls/tls_test.go
-index 42a0272..99bd700 100644
+index d8a43ad..5fa6e90 100644
 --- a/src/crypto/tls/tls_test.go
 +++ b/src/crypto/tls/tls_test.go
-@@ -1098,8 +1098,6 @@
+@@ -1058,8 +1058,6 @@ func TestConnectionState(t *testing.T) {
  	rootCAs := x509.NewCertPool()
  	rootCAs.AddCert(issuer)
  
@@ -228,7 +215,7 @@ index 42a0272..99bd700 100644
  	const alpnProtocol = "golang"
  	const serverName = "example.golang"
  	var scts = [][]byte{[]byte("dummy sct 1"), []byte("dummy sct 2")}
-@@ -1115,7 +1113,7 @@
+@@ -1075,7 +1073,7 @@ func TestConnectionState(t *testing.T) {
  		}
  		t.Run(name, func(t *testing.T) {
  			config := &Config{
@@ -237,12 +224,4 @@ index 42a0272..99bd700 100644
  				Rand:         zeroSource{},
  				Certificates: make([]Certificate, 1),
  				MaxVersion:   v,
-@@ -1729,7 +1727,7 @@
- 			var serverVerifyPeerCertificates, clientVerifyPeerCertificates bool
- 
- 			clientConfig := testConfig.Clone()
--			clientConfig.Time = func() time.Time { return time.Unix(1476984729, 0) }
-+			clientConfig.Time = testTime
- 			clientConfig.MaxVersion = version
- 			clientConfig.MinVersion = version
- 			clientConfig.RootCAs = rootCAs
+-- 

--- a/src/golang/patches/series
+++ b/src/golang/patches/series
@@ -1,1 +1,2 @@
 openssl-config.patch
+go_testcase_cert_expire.patch


### PR DESCRIPTION
Fix go build break because cert expired issue.

#### Why I did it
Go build break because cert expired:

2025-02-01T01:59:48.6089594Z --- FAIL: TestVerifyConnection (0.00s)
2025-02-01T01:59:48.6089953Z     --- FAIL: TestVerifyConnection/TLSv12 (0.00s)
2025-02-01T01:59:48.6090351Z         handshake_client_test.go:1721: RequireAndVerifyClientCert-FullHandshake: handshake failed: remote error: tls: bad certificate
2025-02-01T01:59:48.6090819Z     --- FAIL: TestVerifyConnection/TLSv13 (0.00s)
2025-02-01T01:59:48.6091221Z         handshake_client_test.go:1721: RequireAndVerifyClientCert-FullHandshake: handshake failed: remote error: tls: bad certificate
2025-02-01T01:59:48.6091817Z --- FAIL: TestResumptionKeepsOCSPAndSCT (0.01s)
2025-02-01T01:59:48.6092097Z     --- FAIL: TestResumptionKeepsOCSPAndSCT/TLSv12 (0.00s)
2025-02-01T01:59:48.6092425Z         handshake_client_test.go:2513: handshake failed: remote error: tls: bad certificate
2025-02-01T01:59:48.6092762Z     --- FAIL: TestResumptionKeepsOCSPAndSCT/TLSv13 (0.01s)
2025-02-01T01:59:48.6093096Z         handshake_client_test.go:2513: handshake failed: remote error: tls: bad certificate

##### Work item tracking
- Microsoft ADO: 31063369

#### How I did it
Add upstream fix from here: https://go-review.googlesource.com/c/gofrontend/+/640435

#### How to verify it
Pass all UT.
Manually verify golang debs generated.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [] 

#### Description for the changelog
Fix go build break because cert expired issue.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)


