### PR TITLE
Migrate the agent pool to the new pool

### DIFF
--- a/.azure-pipelines/test-template-armhf.yml
+++ b/.azure-pipelines/test-template-armhf.yml
@@ -14,7 +14,7 @@ parameters:
 jobs:
 - template: build-template.yml
   parameters:
-    pool: sonicbld-armhf
+    pool: sonicso1ES-armhf
     arch: armhf
     image: sonicdev-microsoft.azurecr.io/sonic-slave-bookworm-armhf
     artifactNamePrefix: test-symcrypt-
@@ -22,7 +22,7 @@ jobs:
 - job: QemuTest
   dependsOn: Build${{ parameters.arch }}
   displayName: Qemu-test-${{ parameters.arch }}
-  pool: sonicbld-1es
+  pool: sonicso1ES-amd64
   timeoutInMinutes: 600
   steps:
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,14 +22,14 @@ stages:
   jobs:
   - template: .azure-pipelines/build-template.yml
     parameters:
-      pool: sonicbld-1es
+      pool: sonicso1ES-amd64
   - template: .azure-pipelines/build-template.yml
     parameters:
-      pool: sonicbld-arm64
+      pool: sonicso1ES-arm64
       arch: arm64
   - template: .azure-pipelines/build-template.yml
     parameters:
-      pool: sonicbld-armhf
+      pool: sonicso1ES-armhf
       arch: armhf
       image: sonicdev-microsoft.azurecr.io/sonic-slave-bookworm-armhf
 - stage: test


### PR DESCRIPTION
The old agent pool is no longer available and has been replaced with this new agent pool, which is based on Ubuntu 24.04.