### PR TITLE
Add Trixie (Debian 13) OpenSSL 3.5.x FIPS support

### DIFF
--- a/TRIXIE.md
+++ b/TRIXIE.md
@@ -1,0 +1,46 @@
+# Trixie (Debian 13) FIPS Support
+
+## OpenSSL 3.5.x Compatibility
+
+OpenSSL 3.5.x (shipped in Debian Trixie) introduces several changes that affect FIPS patch compatibility:
+
+### Test Data File Reorganization
+
+OpenSSL 3.5.x split monolithic test data files into per-algorithm files:
+- `evppkey.txt` → `evppkey_rsa.txt`, `evppkey_ecc.txt`, `evppkey_dsa.txt`, etc.
+- `evpciph.txt` → `evpciph_aes_common.txt`, `evpciph_des.txt`, etc.
+- `evpmac.txt` → `evpmac_common.txt`, `evpmac_blake.txt`, etc.
+
+### Patch Compatibility
+
+Of the 7 Bookworm FIPS debian patches, only 3 are needed for Trixie:
+
+| Patch | Status | Notes |
+|-------|--------|-------|
+| `20-support-fips-test.patch` | ✅ Applies (with fuzz) | FIPS test enablement |
+| `70-disable-evp-iv-check.patch` | ✅ Applies (with offset) | EVP IV check bypass |
+| `Remove-the-provider-section.patch` | ✅ Already in Debian | Part of Trixie upstream |
+| `30-disable-some-evppkey-tests-for-fips.patch` | ❌ Not needed | Target file split; tests pass |
+| `40-disable-test-cases-with-fips-enabled.patch` | ❌ Not needed | Partial hunks fail; tests pass |
+| `50-disable-some-evpciph-test-for-fips.patch` | ❌ Not needed | Target file split; tests pass |
+| `60-disable-evpmac-tests-for-fips.patch` | ❌ Not needed | Target file split; tests pass |
+
+### Test Results
+
+Full test suite (343 files, 4471 tests) passes with only the 3 compatible patches applied.
+No `DEB_BUILD_OPTIONS=nocheck` workaround needed.
+
+### Package Differences from Bookworm
+
+| Bookworm (OpenSSL 3.0.x) | Trixie (OpenSSL 3.5.x) |
+|---------------------------|------------------------|
+| `libssl3` | `libssl3t64` (t64 transition) |
+| FIPS provider in `openssl` | Separate `openssl-provider-fips` package |
+| — | Post-quantum: ML-DSA, ML-KEM, SLH-DSA |
+| 18 FIPS self-tests | 41 FIPS self-tests |
+
+### SymCrypt Compatibility
+
+SymCrypt and SymCrypt-OpenSSL build and work on Trixie without modification:
+- `openssl fipsinstall` passes all 41 self-tests
+- SymCrypt provider loads alongside default and FIPS providers

--- a/src/openssl.patch/debian.patch.trixie/20-support-fips-test.patch
+++ b/src/openssl.patch/debian.patch.trixie/20-support-fips-test.patch
@@ -1,0 +1,29 @@
+diff --git a/engines/e_ossltest.c b/engines/e_ossltest.c
+index c925d2c5a6..b1f587291c 100644
+--- a/engines/e_ossltest.c
++++ b/engines/e_ossltest.c
+@@ -428,6 +428,10 @@ static int bind_ossltest(ENGINE *e)
+         return 0;
+     }
+ 
++    ENGINE* scossl = ENGINE_by_id("symcrypt");
++    ENGINE_unregister_pkey_meths(scossl);
++    ENGINE_free(scossl);
++
+     return 1;
+ }
+
+diff --git a/Configurations/unix-Makefile.tmpl b/Configurations/unix-Makefile.tmpl
+index 18255fd43b..24e2b778f3 100644
+--- a/Configurations/unix-Makefile.tmpl
++++ b/Configurations/unix-Makefile.tmpl
+@@ -530,6 +530,9 @@ test: tests
+ {- dependmagic('tests'); -}: build_programs_nodep build_modules_nodep link-utils run_tests
+ run_tests:
+ 	@ : {- output_off() if $disabled{tests}; "" -}
++	( cd test; \
++	  cp $(libdir)/engines-3/symcryptengine.so ../$(BLDDIR)/engines/; \
++	  cp $(libdir)/ossl-modules/symcryptprovider.so ../$(BLDDIR)/providers/;)
+ 	( SRCTOP=$(SRCDIR) \
+ 	  BLDTOP=$(BLDDIR) \
+ 	  PERL="$(PERL)" \

--- a/src/openssl.patch/debian.patch.trixie/70-disable-evp-iv-check.patch
+++ b/src/openssl.patch/debian.patch.trixie/70-disable-evp-iv-check.patch
@@ -1,0 +1,14 @@
+diff --git a/test/evp_test.c b/test/evp_test.c
+index c781f65b3e..2bdfcb2295 100644
+--- a/test/evp_test.c
++++ b/test/evp_test.c
+@@ -812,7 +812,8 @@ static int cipher_test_enc(EVP_TEST *t, int enc,
+     }
+ 
+     /* Check that we get the same IV back */
+-    if (expected->iv != NULL) {
++    if (expected->iv != NULL &&
++        EVP_CIPHER_get0_provider(EVP_CIPHER_CTX_get0_cipher(ctx_base)) != NULL) {
+         /* Some (e.g., GCM) tests use IVs longer than EVP_MAX_IV_LENGTH. */
+         unsigned char iv[128];
+         if (!TEST_true(EVP_CIPHER_CTX_get_updated_iv(ctx_base, iv, sizeof(iv)))

--- a/src/openssl.patch/debian.patch.trixie/series
+++ b/src/openssl.patch/debian.patch.trixie/series
@@ -1,0 +1,2 @@
+20-support-fips-test.patch
+70-disable-evp-iv-check.patch


### PR DESCRIPTION
## Description
Add Trixie/Debian 13 support for FIPS OpenSSL builds.

### Changes
- Add Trixie-specific debian patch series (`src/openssl.patch/debian.patch.trixie/`)
- Add `TRIXIE.md` documenting Trixie FIPS compatibility

### Key Findings
OpenSSL 3.5.x reorganized test data files (split monolithic `evppkey.txt`, `evpciph.txt`, `evpmac.txt` into per-algorithm files). As a result:

- **Only 3 of 7 Bookworm FIPS patches are needed** for Trixie:
  - `20-support-fips-test.patch` ✅
  - `70-disable-evp-iv-check.patch` ✅
  - `Remove-the-provider-section.patch` ✅ (already in Trixie upstream)
- **4 patches dropped** (30, 40, 50, 60) — target files reorganized, tests pass without them
- **Full test suite passes**: 343 files, 4471 tests, zero failures
- **No `nocheck` workaround needed**

### Trixie Package Differences
- `libssl3` → `libssl3t64` (t64 transition)
- FIPS provider in separate `openssl-provider-fips` package
- 41 FIPS self-tests (vs 18 in Bookworm), including post-quantum (ML-DSA, ML-KEM, SLH-DSA)

### Testing
- Built OpenSSL 3.5.4-1~deb13u1+fips in debian:trixie Docker container
- All tests pass with full test suite enabled
- FIPS provider loads and passes all self-tests on SONiC master VS (KVM)
- SymCrypt/SymCrypt-OpenSSL compatible without modification